### PR TITLE
Update Yanju's fix to one benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.liquid/
 *.png
 .DS_Store
 .vscode

--- a/zkevm-circuits/.gitignore
+++ b/zkevm-circuits/.gitignore
@@ -1,0 +1,4 @@
+/target
+.DS_Store
+.vscode
+.idea

--- a/zkevm-circuits/src/bytecode_circuit/bytecode_unroller.rs
+++ b/zkevm-circuits/src/bytecode_circuit/bytecode_unroller.rs
@@ -64,7 +64,8 @@ use crate::table::PoseidonTable;
 /// specify byte in field for encoding bytecode
 pub use eth_types::utils::POSEIDON_HASH_BYTES_IN_FIELD as HASHBLOCK_BYTES_IN_FIELD;
 
-#[flux_rs::ignore] // normalization bug `<Repeat<∃?b0. u8[b0]>[] as Iterator>::Item` <: `u8[?0e#26]` See #701
+#[flux::trusted] // zk-bug-finder modified
+// #[flux_rs::ignore] // normalization bug `<Repeat<∃?b0. u8[b0]>[] as Iterator>::Item` <: `u8[?0e#26]` See #701
 /// Get unrolled hash inputs as inputs to hash circuit
 pub fn unroll_to_hash_input<F: Field, const BYTES_IN_FIELD: usize, const INPUT_LEN: usize>(
     code: impl ExactSizeIterator<Item = u8>,

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -133,8 +133,14 @@ pub fn constrain_is_pad<F: Field>(
     src_addr_end: Column<Advice>,
     is_src_end: &IsEqualConfig<F>,
 ) -> (Expression<F>, Expression<F>) {
-    let [is_pad, is_pad_writer, is_pad_next] =
-        [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(is_pad, at));
+
+    // zk-bug-finder modified
+    // let [is_pad, is_pad_writer, is_pad_next] =
+    //     [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(is_pad, at));
+    let tmp_a = [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(is_pad, at));
+    let is_pad = tmp_a[0].clone();
+    let is_pad_writer = tmp_a[1].clone();
+    let is_pad_next = tmp_a[2].clone();
 
     cb.require_boolean("is_pad is boolean", is_pad.expr());
 
@@ -142,12 +148,20 @@ pub fn constrain_is_pad<F: Field>(
         cb.require_zero("is_pad == 0 on writer rows", is_pad_writer);
     });
 
+    // zk-bug-finder modified
     // Detect when addr == src_addr_end
-    let [is_src_end, is_src_end_next] = [CURRENT, NEXT_STEP].map(|at| {
+    // let [is_src_end, is_src_end_next] = [CURRENT, NEXT_STEP].map(|at| {
+    //     let addr = meta.query_advice(addr, at);
+    //     let src_addr_end = meta.query_advice(src_addr_end, at);
+    //     is_src_end.expr_at(meta, at, addr, src_addr_end)
+    // });
+    let tmp_c = [CURRENT, NEXT_STEP].map(|at| {
         let addr = meta.query_advice(addr, at);
         let src_addr_end = meta.query_advice(src_addr_end, at);
         is_src_end.expr_at(meta, at, addr, src_addr_end)
     });
+    let is_src_end = tmp_c[0].clone();
+    let is_src_end_next = tmp_c[0].clone();
 
     cb.condition(is_first, |cb| {
         cb.require_equal(
@@ -449,8 +463,13 @@ pub fn constrain_bytes_left<F: Field>(
     mask: Expression<F>,
     bytes_left: Column<Advice>,
 ) {
-    let [current, next_row, next_step] =
-        [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(bytes_left, at));
+    // zk-bug-finder modified
+    // let [current, next_row, next_step] =
+    //     [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(bytes_left, at));
+    let tmp_b = [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(bytes_left, at));
+    let current = tmp_b[0].clone();
+    let next_row = tmp_b[1].clone();
+    let next_step = tmp_b[2].clone();
 
     // Initial values derived from the event.
     cb.condition(is_first.expr(), |cb| {

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -161,7 +161,7 @@ pub fn constrain_is_pad<F: Field>(
         is_src_end.expr_at(meta, at, addr, src_addr_end)
     });
     let is_src_end = tmp_c[0].clone();
-    let is_src_end_next = tmp_c[0].clone();
+    let is_src_end_next = tmp_c[1].clone();
 
     cb.condition(is_first, |cb| {
         cb.require_equal(

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -289,43 +289,44 @@ fn gen_tx_log_data() -> CircuitInputBuilder {
     builder
 }
 
-fn gen_access_list_data() -> Block {
-    let test_access_list = AccessList(vec![
-        AccessListItem {
-            address: address!("0x0000000000000000000000000000000000001111"),
-            storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),
-        },
-        AccessListItem {
-            address: address!("0x0000000000000000000000000000000000002222"),
-            storage_keys: [20, 22].map(H256::from_low_u64_be).to_vec(),
-        },
-        AccessListItem {
-            address: address!("0x0000000000000000000000000000000000003333"),
-            storage_keys: [30, 33].map(H256::from_low_u64_be).to_vec(),
-        },
-    ]);
-    let test_ctx = TestContext::<1, 1>::new(
-        None,
-        |accs| {
-            accs[0].address(MOCK_WALLETS[0].address()).balance(eth(20));
-        },
-        |mut txs, _accs| {
-            txs[0]
-                .from(MOCK_WALLETS[0].clone())
-                .to(MOCK_ACCOUNTS[0])
-                .gas_price(gwei(2))
-                .gas(Word::from(0x10000))
-                .value(eth(2))
-                .transaction_type(1) // Set tx type to EIP-2930.
-                .access_list(test_access_list);
-        },
-        |block, _tx| block.number(0xcafeu64),
-    )
-    .unwrap();
-    CircuitTestBuilder::new_from_test_ctx(test_ctx)
-        .build_witness_block()
-        .0
-}
+// zk-bug-finder modified
+// fn gen_access_list_data() -> Block {
+//     let test_access_list = AccessList(vec![
+//         AccessListItem {
+//             address: address!("0x0000000000000000000000000000000000001111"),
+//             storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),
+//         },
+//         AccessListItem {
+//             address: address!("0x0000000000000000000000000000000000002222"),
+//             storage_keys: [20, 22].map(H256::from_low_u64_be).to_vec(),
+//         },
+//         AccessListItem {
+//             address: address!("0x0000000000000000000000000000000000003333"),
+//             storage_keys: [30, 33].map(H256::from_low_u64_be).to_vec(),
+//         },
+//     ]);
+//     let test_ctx = TestContext::<1, 1>::new(
+//         None,
+//         |accs| {
+//             accs[0].address(MOCK_WALLETS[0].address()).balance(eth(20));
+//         },
+//         |mut txs, _accs| {
+//             txs[0]
+//                 .from(MOCK_WALLETS[0].clone())
+//                 .to(MOCK_ACCOUNTS[0])
+//                 .gas_price(gwei(2))
+//                 .gas(Word::from(0x10000))
+//                 .value(eth(2))
+//                 .transaction_type(1) // Set tx type to EIP-2930.
+//                 .access_list(test_access_list);
+//         },
+//         |block, _tx| block.number(0xcafeu64),
+//     )
+//     .unwrap();
+//     CircuitTestBuilder::new_from_test_ctx(test_ctx)
+//         .build_witness_block()
+//         .0
+// }
 
 fn gen_create_data() -> CircuitInputBuilder {
     let code = bytecode! {
@@ -419,11 +420,12 @@ fn copy_circuit_valid_tx_log() {
     assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
-#[test]
-fn copy_circuit_valid_access_list() {
-    let block = gen_access_list_data();
-    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
-}
+// zk-bug-finder modified
+// #[test]
+// fn copy_circuit_valid_access_list() {
+//     let block = gen_access_list_data();
+//     assert_eq!(test_copy_circuit_from_block(block), Ok(()));
+// }
 
 #[test]
 fn copy_circuit_valid_create() {

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
@@ -140,8 +140,8 @@ fn assign_word<F: Field, const N: usize>(
     Ok(())
 }
 
-// rlc cells array, in the reversed byte order
-#[flux_rs::ignore] // TODO: closure to_rustc
+#[flux::trusted] // zk-bug-finder modified
+// #[flux_rs::ignore] // TODO: closure to_rustc
 fn rlc_rev<F: Field, const N: usize>(
     cells: &[Cell<F>; N],
     randomness: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -144,6 +144,7 @@ pub(crate) const N_BYTES_CALLDATASIZE: usize = N_BYTES_U64;
 pub(crate) static EXECUTION_STATE_HEIGHT_MAP: LazyLock<HashMap<ExecutionState, usize>> =
     LazyLock::new(get_step_height_map);
 
+#[flux::trusted] // zk-bug-finder modified
 fn get_step_height_map() -> HashMap<ExecutionState, usize> {
     let mut meta = ConstraintSystem::<Fr>::default();
     let circuit = EvmCircuit::configure(&mut meta);

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -655,7 +655,8 @@ pub(crate) mod rlc {
         }
     }
 
-    #[flux_rs::ignore] // incomplete normalization: invalid deref `<<I as IntoIterator>::IntoIter as Iterator>::Item`
+    #[flux::trusted] // zk-bug-finder modified
+    // #[flux_rs::ignore] // incomplete normalization: invalid deref `<<I as IntoIterator>::IntoIter as Iterator>::Item`
     pub(crate) fn value<'a, F: Field, I>(values: I, randomness: F) -> F
     where
         I: IntoIterator<Item = &'a u8>,


### PR DESCRIPTION
### Description

Update Yanju's fix on running flux to one benchmark that can be compiled using `cargo run`

### Issue Link

Fixing-Flux-on-zkEVM-09-11-2024

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- update from https://github.com/chyanju/zkevm-circuits/commit/ee347f18e90a0da506012ddb0b2904f098af917d

